### PR TITLE
Feat/add update date scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "swagger": "npx ts-node ./src/swagger.ts",
     "postman": "npx p2o ./doc/倍而兔募資平台.postman_collection.json -f ./doc/postman.json -o ./doc/options.json",
     "create": "node src/db/createData.js",
-    "init": "npx ts-node ./src/connections/init.ts"
+    "init": "npx ts-node ./src/connections/init.ts",
+    "update": "npx ts-node ./src/connections/update.ts"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/src/connections/update.ts
+++ b/src/connections/update.ts
@@ -1,6 +1,13 @@
 import mongoose from "mongoose";
 import dotenv from "dotenv";
 import { postponeQas } from "../db/update/updateQas";
+import { postponeUser } from "../db/update/updateUser";
+import { postponeUserProposer } from "../db/update/updateUserProposer";
+import { postponeProject } from "../db/update/updateProject";
+import { postponeOption } from "../db/update/updateOption";
+import { postponeNews } from "../db/update/updateNews";
+import { postponeOrder } from "../db/update/updateOrder";
+// import { postponeOrderInfo } from "../db/update/updateOrderInfo";
 
 dotenv.config({ path: "./.env" });
 
@@ -15,7 +22,14 @@ const DB = process.env.MONGODB_CONNECT_STRING!.replace(
 mongoose.connect(DB).then(async () => {
   console.log("資料庫連接成功");
 
-  await postponeQas();
+  // await postponeQas();
+  await postponeUser();
+  await postponeUserProposer();
+  await postponeProject();
+  await postponeOption();
+  await postponeNews();
+  await postponeOrder();
+  // await postponeOrderInfo();
   console.log("資料庫更新資料完成");
 }).then(() => {
   mongoose.connection.close();

--- a/src/connections/update.ts
+++ b/src/connections/update.ts
@@ -1,0 +1,22 @@
+import mongoose from "mongoose";
+import dotenv from "dotenv";
+import { postponeQas } from "../db/update/updateQas";
+
+dotenv.config({ path: "./.env" });
+
+const DB = process.env.MONGODB_CONNECT_STRING!.replace(
+  "<user>",
+  process.env.MONGODB_USER!
+)
+  .replace("<password>", process.env.MONGODB_PASSWORD!)
+  .replace("<database>", process.env.MONGODB_DATABASE!);
+// const DB = 'mongodb://localhost:27017/test'
+
+mongoose.connect(DB).then(async () => {
+  console.log("資料庫連接成功");
+
+  await postponeQas();
+  console.log("資料庫更新資料完成");
+}).then(() => {
+  mongoose.connection.close();
+});

--- a/src/db/update/updateNews.ts
+++ b/src/db/update/updateNews.ts
@@ -1,0 +1,40 @@
+import News from "../../model/newsModels";
+
+type UpdateFields = {
+  news_create_date: Date;
+  news_end_date: Date;
+  news_start_date?: Date;
+  news_update_date?: Date;
+}
+
+const postponeNews = async (nYears: number = 1) => {
+  // Fetch all documents
+  const newsDocuments = await News.find();
+
+  for (const newsDocument of newsDocuments) {
+    const updateFields: UpdateFields = {
+      news_create_date: new Date(newsDocument.news_create_date.setFullYear(newsDocument.news_create_date.getFullYear() + nYears)),
+      news_end_date: new Date(newsDocument.news_end_date.setFullYear(newsDocument.news_end_date.getFullYear() + nYears)),
+    };
+
+    if (newsDocument.news_start_date) {
+      updateFields.news_start_date = new Date(newsDocument.news_start_date.setFullYear(newsDocument.news_start_date.getFullYear() + nYears))
+    }
+
+    if (newsDocument.news_update_date) {
+      updateFields.news_update_date = new Date(newsDocument.news_update_date.setFullYear(newsDocument.news_update_date.getFullYear() + nYears))
+    }
+
+    const newNews = await News.findByIdAndUpdate(newsDocument._id, updateFields, { new: true });
+
+    if (!newNews) {
+      console.log('更新 News 失敗');
+    } else {
+      console.log('更新 News 成功');
+    }
+  }
+}
+
+export {
+  postponeNews
+};

--- a/src/db/update/updateOption.ts
+++ b/src/db/update/updateOption.ts
@@ -1,0 +1,42 @@
+import Option from "../../model/optionModels";
+
+type UpdateFields = {
+  option_start_date?: Date;
+  option_end_date?: Date;
+  option_create_date: Date;
+  option_update_date?: Date;
+}
+
+const postponeOption = async (nYears: number = 1) => {
+  const optionDocuments = await Option.find();
+
+  for (const optionDocument of optionDocuments) {
+    const updateFields: UpdateFields = {
+      option_create_date: new Date(optionDocument.option_create_date.setFullYear(optionDocument.option_create_date.getFullYear() + nYears)),
+    };
+
+    if (optionDocument.option_start_date) {
+      updateFields.option_start_date = new Date(optionDocument.option_start_date.setFullYear(optionDocument.option_start_date.getFullYear() + nYears));
+    }
+
+    if (optionDocument.option_end_date) {
+      updateFields.option_end_date = new Date(optionDocument.option_end_date.setFullYear(optionDocument.option_end_date.getFullYear() + nYears));
+    }
+
+    if (optionDocument.option_update_date) {
+      updateFields.option_update_date = new Date(optionDocument.option_update_date.setFullYear(optionDocument.option_update_date.getFullYear() + nYears));
+    }
+
+    const newOption = await Option.findByIdAndUpdate(optionDocument._id, updateFields, { new: true });
+
+    if (!newOption) {
+      console.log('更新 Option 失敗');
+    } else {
+      console.log('更新 Option 成功');
+    }
+  }
+}
+
+export {
+  postponeOption
+};

--- a/src/db/update/updateOrder.ts
+++ b/src/db/update/updateOrder.ts
@@ -1,0 +1,38 @@
+import Order from "../../model/orderModels";
+
+type UpdateFields = {
+  order_create_date: Date;
+  order_shipping_date?: Date;
+  order_final_date?: Date;
+}
+
+const postponeOrder = async (nYears: number = 1) => {
+  const orderDocuments = await Order.find();
+
+  for (const orderDocument of orderDocuments) {
+    const updateFields: UpdateFields = {
+      order_create_date: new Date(orderDocument.order_create_date.setFullYear(orderDocument.order_create_date.getFullYear() + nYears))
+      
+    };
+
+    if (orderDocument.order_shipping_date) {
+      updateFields.order_shipping_date = new Date(orderDocument.order_shipping_date.setFullYear(orderDocument.order_shipping_date.getFullYear() + nYears));
+    }
+
+    if (orderDocument.order_final_date) {
+      updateFields.order_final_date = new Date(orderDocument.order_final_date.setFullYear(orderDocument.order_final_date.getFullYear() + nYears));
+    }
+
+    const newOrder = await Order.findByIdAndUpdate(orderDocument._id, updateFields, { new: true });
+
+    if (!newOrder) {
+      console.log('更新 Order 失敗');
+    } else {
+      console.log('更新 Order 成功');
+    }
+  }
+}
+
+export {
+  postponeOrder
+};

--- a/src/db/update/updateProject.ts
+++ b/src/db/update/updateProject.ts
@@ -1,0 +1,42 @@
+import Project from "../../model/projectModels";
+
+type UpdateFields = {
+  project_create_date: Date;
+  project_update_date?: Date;
+  project_start_date?: Date;
+  project_end_date?: Date;
+}
+
+const postponeProject = async (nYears: number = 1) => {
+  const projectDocuments = await Project.find();
+
+  for (const projectDocument of projectDocuments) {
+    const updateFields: UpdateFields = {
+      project_create_date: new Date(projectDocument.project_create_date.setFullYear(projectDocument.project_create_date.getFullYear() + nYears)),
+    };
+
+    if (projectDocument.project_start_date) {
+      updateFields.project_start_date = new Date(projectDocument.project_start_date.setFullYear(projectDocument.project_start_date.getFullYear() + nYears));
+    }
+
+    if (projectDocument.project_end_date) {
+      updateFields.project_end_date = new Date(projectDocument.project_end_date.setFullYear(projectDocument.project_end_date.getFullYear() + nYears));
+    }
+
+    if (projectDocument.project_update_date) {
+      updateFields.project_update_date = new Date(projectDocument.project_update_date.setFullYear(projectDocument.project_update_date.getFullYear() + nYears));
+    }
+
+    const newProject = await Project.findByIdAndUpdate(projectDocument._id, updateFields, { new: true });
+
+    if (!newProject) {
+      console.log('更新 Project 失敗');
+    } else {
+      console.log('更新 Project 成功');
+    }
+  }
+}
+
+export {
+  postponeProject
+};

--- a/src/db/update/updateQas.ts
+++ b/src/db/update/updateQas.ts
@@ -1,0 +1,38 @@
+import Qas from "../../model/qasModels";
+
+const postponeQas = async (nYears: number = 1) => {
+  // Fetch all documents
+  const qasDocuments = await Qas.find();
+
+  for (const qasDocument of qasDocuments) {
+    let newQas;
+    if (qasDocument.qas_update_date) {
+      newQas = await Qas.findByIdAndUpdate(
+        qasDocument._id,
+        {
+          qas_create_date: new Date(qasDocument.qas_create_date.setFullYear(qasDocument.qas_create_date.getFullYear() + nYears)),
+          qas_update_date: new Date(qasDocument.qas_update_date.setFullYear(qasDocument.qas_update_date.getFullYear() + nYears))
+        },
+        { new: true }
+      );
+    } else {
+      newQas = await Qas.findByIdAndUpdate(
+        qasDocument._id,
+        {
+          qas_create_date: new Date(qasDocument.qas_create_date.setFullYear(qasDocument.qas_create_date.getFullYear() + nYears))
+        },
+        { new: true }
+      );
+    }
+
+    if (!newQas) {
+      console.log('更新 Qas 失敗');
+    } else {
+      console.log('更新 Qas 成功');
+    }
+  }
+}
+
+export {
+  postponeQas
+};

--- a/src/db/update/updateQas.ts
+++ b/src/db/update/updateQas.ts
@@ -1,29 +1,23 @@
 import Qas from "../../model/qasModels";
 
+type UpdateFields = {
+  qas_create_date: Date;
+  qas_update_date?: Date;
+}
+
 const postponeQas = async (nYears: number = 1) => {
-  // Fetch all documents
   const qasDocuments = await Qas.find();
 
   for (const qasDocument of qasDocuments) {
-    let newQas;
+    const updateFields: UpdateFields = {
+      qas_create_date: new Date(qasDocument.qas_create_date.setFullYear(qasDocument.qas_create_date.getFullYear() + nYears))
+    };
+
     if (qasDocument.qas_update_date) {
-      newQas = await Qas.findByIdAndUpdate(
-        qasDocument._id,
-        {
-          qas_create_date: new Date(qasDocument.qas_create_date.setFullYear(qasDocument.qas_create_date.getFullYear() + nYears)),
-          qas_update_date: new Date(qasDocument.qas_update_date.setFullYear(qasDocument.qas_update_date.getFullYear() + nYears))
-        },
-        { new: true }
-      );
-    } else {
-      newQas = await Qas.findByIdAndUpdate(
-        qasDocument._id,
-        {
-          qas_create_date: new Date(qasDocument.qas_create_date.setFullYear(qasDocument.qas_create_date.getFullYear() + nYears))
-        },
-        { new: true }
-      );
+      updateFields.qas_update_date = new Date(qasDocument.qas_update_date.setFullYear(qasDocument.qas_update_date.getFullYear() + nYears));
     }
+
+    const newQas = await Qas.findByIdAndUpdate(qasDocument._id, updateFields, { new: true });
 
     if (!newQas) {
       console.log('更新 Qas 失敗');

--- a/src/db/update/updateUser.ts
+++ b/src/db/update/updateUser.ts
@@ -1,0 +1,32 @@
+import { User } from '../../model/userModels';
+
+type UpdateFields = {
+  user_create_date: Date;
+  user_update_date?: Date;
+}
+
+const postponeUser = async (nYears: number = 1) => {
+  const userDocuments = await User.find();
+
+  for (const userDocument of userDocuments) {
+    const updateFields: UpdateFields = {
+      user_create_date: new Date(userDocument.user_create_date.setFullYear(userDocument.user_create_date.getFullYear() + nYears))
+    };
+
+    if (userDocument.user_update_date) {
+      updateFields.user_update_date = new Date(userDocument.user_update_date.setFullYear(userDocument.user_update_date.getFullYear() + nYears));
+    }
+
+    const newUser = await User.findByIdAndUpdate(userDocument._id, updateFields, { new: true });
+
+    if (!newUser) {
+      console.log('更新 User 失敗');
+    } else {
+      console.log('更新 User 成功');
+    }
+  }
+}
+
+export {
+  postponeUser
+};

--- a/src/db/update/updateUserProposer.ts
+++ b/src/db/update/updateUserProposer.ts
@@ -1,0 +1,32 @@
+import UserProposer from "../../model/userProposerModels";
+
+type UpdateFields = {
+  proposer_create_date: Date;
+  proposer_update_date?: Date;
+}
+
+const postponeUserProposer = async (nYears: number = 1) => {
+  const proposerDocuments = await UserProposer.find();
+
+  for (const proposerDocument of proposerDocuments) {
+    const updateFields: UpdateFields = {
+      proposer_create_date: new Date(proposerDocument.proposer_create_date.setFullYear(proposerDocument.proposer_create_date.getFullYear() + nYears))
+    };
+
+    if (proposerDocument.proposer_update_date) {
+      updateFields.proposer_update_date = new Date(proposerDocument.proposer_update_date.setFullYear(proposerDocument.proposer_update_date.getFullYear() + nYears));
+    }
+
+    const newUserProposer = await UserProposer.findByIdAndUpdate(proposerDocument._id, updateFields, { new: true });
+
+    if (!newUserProposer) {
+      console.log('更新 UserProposer 失敗');
+    } else {
+      console.log('更新 UserProposer 成功');
+    }
+  }
+}
+
+export {
+  postponeUserProposer
+};


### PR DESCRIPTION
- 新增可以更新日期的腳本，指令為 `npm run update`，就會把所有 DB 中的日期延後一年
- 但是不含 `orderinfo`，我怕會有問題 (但也不影響 demo 就是了)